### PR TITLE
csv2counter 周回場所を実行時オプション --place で指定可能にする

### DIFF
--- a/csv2counter.py
+++ b/csv2counter.py
@@ -7,7 +7,7 @@ import argparse
 monyupi_list = ['剣モ', '弓モ', '槍モ', '騎モ', '術モ', '殺モ', '狂モ',
                 '剣ピ', '弓ピ', '槍ピ', '騎ピ', '術ピ', '殺ピ', '狂ピ', ]
 
-skilstone_list = [  '剣秘', '弓秘', '槍秘', '騎秘', '術秘', '殺秘', '狂秘',
+skillstone_list = [ '剣秘', '弓秘', '槍秘', '騎秘', '術秘', '殺秘', '狂秘',
                     '剣魔', '弓魔', '槍魔', '騎魔', '術魔', '殺魔', '狂魔',
                     '剣輝', '弓輝', '槍輝', '騎輝', '術輝', '殺輝', '狂輝']
 
@@ -37,9 +37,9 @@ if __name__ == '__main__':
         if i == 2:
             print (l[0][item] + "周")
         if i > 2:
-            if skillstone_flag == False and item in skilstone_list:
+            if skillstone_flag == False and item in skillstone_list:
                 output = output[:-1] + "\n"
-                skillstone_flag = True                
+                skillstone_flag = True
             elif skillstone_flag == True and item not in skillstone_list:
                 output = output[:-1] + "\n"
                 skillstone_flag = False
@@ -68,4 +68,3 @@ if __name__ == '__main__':
 
     print (output[:-1])
     print ("#FGO周回カウンタ http://aoshirobo.net/fatego/rc/")
-

--- a/csv2counter.py
+++ b/csv2counter.py
@@ -17,6 +17,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('infile', nargs='?', type=argparse.FileType(),
                         default=sys.stdin)
+    parser.add_argument('--place', default='周回場所')
     args = parser.parse_args()
 
     with args.infile as f:
@@ -27,7 +28,7 @@ if __name__ == '__main__':
         if item['filename'] == "missing":
             print("missing なデータがあります", file=sys.stderr)
             sys.exit(1)
-    print ("【周回場所】", end="")
+    print ("【{}】".format(args.place), end="")
     output = ""
     monyupi_flag = False
     skillstone_flag = False


### PR DESCRIPTION
引数 `--place` ありの実行例です。

```
(fgosccnt) vagrant@ubuntu-eoan:/vshare/github/fgosccnt$ ./csv2counter.py result_20200328_1.csv --place "テスト撃退戦 テスト級"
【テスト撃退戦 テスト級】30周
胆石5-鉄杭20
槍モ21-槍ピ6
コイン(+3000)53-コイン(+6000)30-チョーク(x3)300-チョーク(x5)55
QP(+500000)28-QP(+520000)30-QP(+400000)16-QP(+300000)10
経験値礼装3-城塞の午後1
#FGO周回カウンタ http://aoshirobo.net/fatego/rc/
```

引数なしの場合は従来と同じです。

```
(fgosccnt) vagrant@ubuntu-eoan:/vshare/github/fgosccnt$ ./csv2counter.py result_20200328_1.csv
【周回場所】30周
胆石5-鉄杭20
槍モ21-槍ピ6
コイン(+3000)53-コイン(+6000)30-チョーク(x3)300-チョーク(x5)55
QP(+500000)28-QP(+520000)30-QP(+400000)16-QP(+300000)10
経験値礼装3-城塞の午後1
#FGO周回カウンタ http://aoshirobo.net/fatego/rc/
```

その他:

変数名 `skilstone_list` と `skillstone_list` が混在していたので、後者にそろえておきました。